### PR TITLE
Dev/validator state

### DIFF
--- a/composer/docker-compose.yaml
+++ b/composer/docker-compose.yaml
@@ -5,11 +5,9 @@ services:
     restart: unless-stopped
     entrypoint: |
       /bin/sh -c '
-      echo "Running preparation script..." "$@"
+      echo "Running preparation script..."
       cat /etc/prometheus/namada-alerts.yml | sed "s/[$][$]CHAIN_ID[$][$]/$CHAIN_ID/g" > /etc/prometheus/namada-alerts-$CHAIN_ID.yml
       cat /etc/prometheus/prometheus.yml | sed "s/[$][$]CHAIN_ID[$][$]/$CHAIN_ID/g" > /etc/prometheus/prometheus-$CHAIN_ID.yml
-
-      tail -n 23472 /etc/prometheus/namada-alerts-$CHAIN_ID.yml /etc/prometheus/prometheus-$CHAIN_ID.yml
       exec /bin/prometheus --config.file=/etc/prometheus/prometheus-$CHAIN_ID.yml --storage.tsdb.retention.time=30d
       '
     ports:

--- a/composer/provisioning/prometheus/namada-alerts.yml
+++ b/composer/provisioning/prometheus/namada-alerts.yml
@@ -165,8 +165,8 @@ groups:
   - alert: AbnormalConsensusValidatorIncrease
     expr: |
       (
-        namada_consensus_validators{chain_id="$$CHAIN_ID$$"}
-        - avg_over_time(namada_consensus_validators{chain_id="$$CHAIN_ID$$"}[7d])
+        abs(namada_consensus_validators{chain_id="$$CHAIN_ID$$"}
+        - avg_over_time(namada_consensus_validators{chain_id="$$CHAIN_ID$$"}[7d]))
       ) > (2 * stddev_over_time(namada_consensus_validators{chain_id="$$CHAIN_ID$$"}[7d]))
     labels:
       severity: warning
@@ -179,8 +179,8 @@ groups:
   - alert: AbnormalInactiveValidatorIncrease
     expr: |
       (
-        namada_inactive_validators{chain_id="$$CHAIN_ID$$"}
-        - avg_over_time(namada_inactive_validators{chain_id="$$CHAIN_ID$$"}[7d])
+        abs(namada_inactive_validators{chain_id="$$CHAIN_ID$$"}
+        - avg_over_time(namada_inactive_validators{chain_id="$$CHAIN_ID$$"}[7d]))
       ) > (2 * stddev_over_time(namada_inactive_validators{chain_id="$$CHAIN_ID$$"}[7d]))
     labels:
       severity: warning
@@ -193,8 +193,8 @@ groups:
   - alert: AbnormalJailedValidatorIncrease
     expr: |
       (
-        namada_jailed_validators{chain_id="$$CHAIN_ID$$"}
-        - avg_over_time(namada_jailed_validators{chain_id="$$CHAIN_ID$$"}[7d])
+        abs(namada_jailed_validators{chain_id="$$CHAIN_ID$$"}
+        - avg_over_time(namada_jailed_validators{chain_id="$$CHAIN_ID$$"}[7d]))
       ) > (2 * stddev_over_time(namada_jailed_validators{chain_id="$$CHAIN_ID$$"}[7d]))
     labels:
       severity: critical
@@ -208,8 +208,8 @@ groups:
   - alert: AbnormalBelowThresholdValidatorIncrease
     expr: |
       (
-        namada_below_threshold_validators{chain_id="$$CHAIN_ID$$"}
-        - avg_over_time(namada_below_threshold_validators{chain_id="$$CHAIN_ID$$"}[7d])
+        abs(namada_below_threshold_validators{chain_id="$$CHAIN_ID$$"}
+        - avg_over_time(namada_below_threshold_validators{chain_id="$$CHAIN_ID$$"}[7d]))
       ) > (2 * stddev_over_time(namada_below_threshold_validators{chain_id="$$CHAIN_ID$$"}[7d]))
     labels:
       severity: warning
@@ -222,8 +222,8 @@ groups:
   - alert: AbnormalBelowCapacityValidatorIncrease
     expr: |
       (
-        namada_below_capacity_validators{chain_id="$$CHAIN_ID$$"}
-        - avg_over_time(namada_below_capacity_validators{chain_id="$$CHAIN_ID$$"}[7d])
+        abs(namada_below_capacity_validators{chain_id="$$CHAIN_ID$$"}
+        - avg_over_time(namada_below_capacity_validators{chain_id="$$CHAIN_ID$$"}[7d]))
       ) > (2 * stddev_over_time(namada_below_capacity_validators{chain_id="$$CHAIN_ID$$"}[7d]))
     labels:
       severity: warning

--- a/composer/provisioning/prometheus/namada-alerts.yml
+++ b/composer/provisioning/prometheus/namada-alerts.yml
@@ -8,41 +8,56 @@ groups:
     annotations:
       summary: "Namada block height is not increasing"
       description: |
-          The validators at {{ $labels.chain_id }} appears to be stalled as the block height has not increased for 5 minutes. 
-          Last recorded block height: {{ with query "namada_block_height{chain_id=\"$$CHAIN_ID$$\"}" }} {{ printf "%.0f" (. | first | value)}}{{ end }}
+          Validators appear to be stalled as the block height has not increased for 1 minute! 
+          Last recorded block height: {{ with query "namada_block_height{chain_id=\"$$CHAIN_ID$$\"}" }} {{ printf "%d" (. | first | value)}}{{ end }}
 
   - alert: NamadaBlockProcessingSlow
-    expr: rate(namada_block_time_sum[5m]) / rate(namada_block_time_count[5m]) > 10
+    expr: |
+      (
+        avg_over_time(namada_block_time_sum{chain_id="$$CHAIN_ID$$"}[5m]) 
+        / avg_over_time(namada_block_time_count{chain_id="$$CHAIN_ID$$"}[5m])
+      ) 
+      > 
+      (
+        avg_over_time(namada_block_time_sum{chain_id="$$CHAIN_ID$$"}[1w]) 
+        / avg_over_time(namada_block_time_count{chain_id="$$CHAIN_ID$$"}[1w])
+      ) 
+      + 
+      (
+        2 * (
+          stddev_over_time(namada_block_time_sum{chain_id="$$CHAIN_ID$$"}[1w]) 
+          / avg_over_time(namada_block_time_count{chain_id="$$CHAIN_ID$$"}[1w])
+        )
+      )
     labels:
       severity: warning
     annotations:
-      summary: "Namada block processing time is slow"
+      summary: "Namada block processing time is abnormal"
       description: |
-        The average block processing time has exceeded 10 seconds considering the the last 5 minutes of data. 
-        Block height: {{ with query "namada_block_height{chain_id=\"$$CHAIN_ID$$\"}" }}{{ printf "%.0f" (. | first | value)}}{{ end }}. 
-        Chain id: {{ $labels.chain_id }}
+        The average block processing time in the last 5 minutes is significantly higher than normal. 
+        Current 5-minute average block time: {{ with query "(avg_over_time(namada_block_time_sum{chain_id=\"$$CHAIN_ID$$\"}[5m]) / avg_over_time(namada_block_time_count{chain_id=\"$$CHAIN_ID$$\"}[5m]))" }}{{ printf "%ds" (. | first | value) }}{{ end }}
+        Expected to be below: {{ with query "avg_over_time(namada_block_time_sum{chain_id=\"$$CHAIN_ID$$\"}[1w]) / avg_over_time(namada_block_time_count{chain_id=\"$$CHAIN_ID$$\"}[1w]) + (2 * (stddev_over_time(namada_block_time_sum{chain_id=\"$$CHAIN_ID$$\"}[1w]) / stddev_over_time(namada_block_time_count{chain_id=\"$$CHAIN_ID$$\"}[1w])))" }}{{ printf "%ds" (. | first | value) }}{{ end }}
+        Block height: {{ with query "namada_block_height{chain_id=\"$$CHAIN_ID$$\"}" }}{{ printf "%d" (. | first | value) }}{{ end }}
 
   - alert: NamadaVotingPowerConcentration
     expr: namada_one_third_threshold{ chain_id="$$CHAIN_ID$$" } > 0.6 * namada_two_third_threshold{ chain_id="$$CHAIN_ID$$" }
     labels:
       severity: critical
     annotations:
-      summary: "Low validator participation detected"
+      summary: "Voting power is too concentrated"
       description: |
-        The number of validators needed for 1/3 of the voting power if more than half the number of validators nded for 2/3 voting power. 
-        Block height: {{ with query "namada_block_height{ chain_id=\"$$CHAIN_ID$$\" }" }}{{ printf "%.0f" (. | first | value)}}{{ end }}
-        Chain id: {{ $labels.chain_id }}
+        The number of validators needed for 1/3 of the voting power is greater than 60% of the number of validators neededed for 2/3 voting power. 
+        Block height: {{ with query "namada_block_height{ chain_id=\"$$CHAIN_ID$$\" }" }}{{ printf "%d" (. | first | value)}}{{ end }}
 
   - alert: NamadaLowValidatorParticipation
     expr: namada_one_third_threshold{ chain_id="$$CHAIN_ID$$" } < 1 or namada_two_third_threshold{ chain_id="$$CHAIN_ID$$" } < 1
     labels:
       severity: critical
     annotations:
-      summary: "Low validator participation detected"
+      summary: "Very low validator participation detected"
       description: |
         The number of validators needed for 1/3 or 2/3 consensus is at zero, which indicates a potential network failure. 
-        Block height: {{ with query "namada_block_height{ chain_id=\"$$CHAIN_ID$$\" }" }}{{ printf "%.0f" (. | first | value)}}{{ end }}
-        Chain id: {{ $labels.chain_id }}
+        Block height: {{ with query "namada_block_height{ chain_id=\"$$CHAIN_ID$$\" }" }}{{ printf "%d" (. | first | value)}}{{ end }}
 
   - alert: NamadaAbnormalBonding
     expr: rate(namada_bonds_per_epoch{ chain_id="$$CHAIN_ID$$" }[10m]) > 1.5 * avg_over_time(namada_bonds_per_epoch{ chain_id="$$CHAIN_ID$$" }[7d])
@@ -52,8 +67,7 @@ groups:
       summary: "Unusual increase in bonding activity"
       description: |
         Bonding per epoch has increased significantly over the last 10 minutes compared to the average of last 7 days. 
-        Block height: {{ with query "namada_block_height{ chain_id=\"$$CHAIN_ID$$\" }" }}{{ printf "%.0f" (. | first | value)}}{{ end }}
-        Chain id: {{ $labels.chain_id }}
+        Block height: {{ with query "namada_block_height{ chain_id=\"$$CHAIN_ID$$\" }" }}{{ printf "%d" (. | first | value)}}{{ end }}
 
   - alert: NamadaAbnormalUnbonding
     expr: rate(namada_unbonds_per_epoch{ chain_id="$$CHAIN_ID$$" }[10m]) > 1.5 * avg_over_time(namada_unbonds_per_epoch{ chain_id="$$CHAIN_ID$$" }[7d])
@@ -63,8 +77,7 @@ groups:
       summary: "Unusual increase in unbonding activity"
       description: |
         Unbonding per epoch has increased significantly over the last 10 minutes compared to the average of last 7 days.
-        Block height: {{ with query "namada_block_height{ chain_id=\"$$CHAIN_ID$$\" }" }}{{ printf "%.0f" (. | first | value)}}{{ end }}
-        Chain id: {{ $labels.chain_id }}
+        Block height: {{ with query "namada_block_height{ chain_id=\"$$CHAIN_ID$$\" }" }}{{ printf "%d" (. | first | value)}}{{ end }}
 
   - alert: NamadaTransactionBatchSpike
     expr: |
@@ -75,8 +88,7 @@ groups:
       summary: "Spike in transaction batch size"
       description: |
         Transaction batching has significantly increased over the last 10 minutes compared to the 7-day median. 
-        Block height: {{ with query "namada_block_height{ chain_id=\"$$CHAIN_ID$$\" }" }}{{ printf "%.0f" (. | first | value)}}{{ end }}
-        Chain id: {{ $labels.chain_id }}
+        Block height: {{ with query "namada_block_height{ chain_id=\"$$CHAIN_ID$$\" }" }}{{ printf "%d" (. | first | value)}}{{ end }}
         
   - alert: HighTransactionFeesAnomaly
     expr: |
@@ -91,9 +103,8 @@ groups:
       summary: "Anomalous Transaction Fees for Token {{ $labels.token }}"
       description: |
         Transaction fees per block for token {{ $labels.token }} have exceeded the expected range. 
-        Current: {{ $value }}. 
+        Current value: {{ $value }}. 
         Expected: < {{ with query "sum by (token) (avg_over_time(namada_fees{ chain_id=\"$$CHAIN_ID$$\" }[10m])) + 2 * sum by (token) (stddev_over_time(namada_fees{ chain_id=\"$$CHAIN_ID$$\" }[10m]))" }}{{ printf "%.2f" (. | first | value)}}{{ end }}.
-        Chain id: {{ $labels.chain_id }}
 
   - alert: HighTransactionFeesAvg
     expr: |
@@ -110,7 +121,6 @@ groups:
         Transaction fees per block for token {{ $labels.token }} are unusually high. 
         Current: {{ $value }} NAM. 
         Expected: < {{ with query "scalar(sum by (token) (avg_over_time(namada_fees{ chain_id=\"$$CHAIN_ID$$\" }[10m]))) + 2 * scalar(sum by (token) (stddev_over_time(namada_fees{ chain_id=\"$$CHAIN_ID$$\" }[10m])))" }}{{ printf "%.2f" (. | first | value)}}{{ end }} NAM.
-        Chain id: {{ $labels.chain_id }}
 
   - alert: AbnormalInnerTransactionFailureRate
     expr: |
@@ -122,11 +132,9 @@ groups:
     annotations:
       summary: "Unusual spike in inner transaction failures"
       description: |
-        The failure rate of inner transactions has spiked abnormally.
-        Current failure rate: {{ $value }}
-        This is **more than 2x the historical median** failure rate over the past 7 days.
-        Block height: {{ with query "namada_block_height{chain_id=\"$$CHAIN_ID$$\"}" }}{{ printf "%.0f" (. | first | value) }}{{ end }}
-        Chain id: {{ $labels.chain_id }}
+        The failure rate of inner transactions has spiked abnormally compared against the median in the last 7 days.
+        Block height: {{ with query "namada_block_height{chain_id=\"$$CHAIN_ID$$\"}" }}{{ printf "%d" (. | first | value) }}{{ end }}
+        Current failure rate: {{ with query "rate(namada_transaction_kind{chain_id=\"$$CHAIN_ID$$\", failed=\"true\"}[10m])" }}{{ printf "%.2f" (. | first | value)}}{{ end }}
 
   - alert: WhaleTransactionDetected
     expr: |
@@ -141,8 +149,7 @@ groups:
         A large transfer was detected in {{ $labels.token }}.
         Transfer Amount: {{ $value }} {{ $labels.token }}
         This exceeds 2x the standard deviation from the average transfer amount in the last 7 days.
-        Block height: {{ with query "namada_block_height{chain_id=\"$$CHAIN_ID$$\"} " }}{{ printf "%.0f" (. | first | value) }}{{ end }}
-        Chain id: {{ $labels.chain_id }}
+        Block height: {{ with query "namada_block_height{chain_id=\"$$CHAIN_ID$$\"} " }}{{ printf "%d" (. | first | value) }}{{ end }}
 
   - alert: HighSlashingRate
     expr: |
@@ -153,80 +160,75 @@ groups:
       summary: "Unusual number of validator slashes"
       description: |
         Slashing detected.
-        Block height: {{ with query "namada_block_height{chain_id=\"$$CHAIN_ID$$\"}" }}{{ printf "%.0f" (. | first | value) }}{{ end }}
-        Chain id: {{ $labels.chain_id }}
-
+        Block height: {{ with query "namada_block_height{chain_id=\"$$CHAIN_ID$$\"}" }}{{ printf "%d" (. | first | value) }}{{ end }}
+       
   - alert: AbnormalConsensusValidatorIncrease
     expr: |
       (
-        namada_consensus_validators{chain_id="namada.5f5de2dd1b88cba30586420"}
-        - avg_over_time(namada_consensus_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h])
-      ) > (2 * stddev_over_time(namada_consensus_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h]))
-    for: 10m
+        namada_consensus_validators{chain_id="$$CHAIN_ID$$"}
+        - avg_over_time(namada_consensus_validators{chain_id="$$CHAIN_ID$$"}[7d])
+      ) > (2 * stddev_over_time(namada_consensus_validators{chain_id="$$CHAIN_ID$$"}[7d]))
     labels:
       severity: warning
     annotations:
       summary: "Abnormal increase in consensus validators"
       description: |
         The number of validators in the consensus state has increased abnormally.
-        Chain ID: namada.5f5de2dd1b88cba30586420
+        Block height: {{ with query "namada_block_height{chain_id=\"$$CHAIN_ID$$\"}" }}{{ printf "%d" (. | first | value) }}{{ end }}
 
   - alert: AbnormalInactiveValidatorIncrease
     expr: |
       (
-        namada_inactive_validators{chain_id="namada.5f5de2dd1b88cba30586420"}
-        - avg_over_time(namada_inactive_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h])
-      ) > (2 * stddev_over_time(namada_inactive_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h]))
-    for: 10m
+        namada_inactive_validators{chain_id="$$CHAIN_ID$$"}
+        - avg_over_time(namada_inactive_validators{chain_id="$$CHAIN_ID$$"}[7d])
+      ) > (2 * stddev_over_time(namada_inactive_validators{chain_id="$$CHAIN_ID$$"}[7d]))
     labels:
       severity: warning
     annotations:
       summary: "Abnormal increase in inactive validators"
       description: |
         The number of inactive validators has increased abnormally.
-        Chain ID: namada.5f5de2dd1b88cba30586420
+        Block height: {{ with query "namada_block_height{chain_id=\"$$CHAIN_ID$$\"}" }}{{ printf "%d" (. | first | value) }}{{ end }}
 
   - alert: AbnormalJailedValidatorIncrease
     expr: |
       (
-        namada_jailed_validators{chain_id="namada.5f5de2dd1b88cba30586420"}
-        - avg_over_time(namada_jailed_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h])
-      ) > (2 * stddev_over_time(namada_jailed_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h]))
-    for: 10m
+        namada_jailed_validators{chain_id="$$CHAIN_ID$$"}
+        - avg_over_time(namada_jailed_validators{chain_id="$$CHAIN_ID$$"}[7d])
+      ) > (2 * stddev_over_time(namada_jailed_validators{chain_id="$$CHAIN_ID$$"}[7d]))
     labels:
       severity: critical
     annotations:
       summary: "Abnormal increase in jailed validators"
       description: |
         The number of jailed validators has increased abnormally.
-        Chain ID: namada.5f5de2dd1b88cba30586420
+        Block height: {{ with query "namada_block_height{chain_id=\"$$CHAIN_ID$$\"}" }}{{ printf "%d" (. | first | value) }}{{ end }}
+
 
   - alert: AbnormalBelowThresholdValidatorIncrease
     expr: |
       (
-        namada_below_threshold_validators{chain_id="namada.5f5de2dd1b88cba30586420"}
-        - avg_over_time(namada_below_threshold_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h])
-      ) > (2 * stddev_over_time(namada_below_threshold_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h]))
-    for: 10m
+        namada_below_threshold_validators{chain_id="$$CHAIN_ID$$"}
+        - avg_over_time(namada_below_threshold_validators{chain_id="$$CHAIN_ID$$"}[7d])
+      ) > (2 * stddev_over_time(namada_below_threshold_validators{chain_id="$$CHAIN_ID$$"}[7d]))
     labels:
       severity: warning
     annotations:
       summary: "Abnormal increase in below-threshold validators"
       description: |
         The number of validators below the threshold has increased abnormally.
-        Chain ID: namada.5f5de2dd1b88cba30586420
+        Block height: {{ with query "namada_block_height{chain_id=\"$$CHAIN_ID$$\"}" }}{{ printf "%d" (. | first | value) }}{{ end }}
 
   - alert: AbnormalBelowCapacityValidatorIncrease
     expr: |
       (
-        namada_below_capacity_validators{chain_id="namada.5f5de2dd1b88cba30586420"}
-        - avg_over_time(namada_below_capacity_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h])
-      ) > (2 * stddev_over_time(namada_below_capacity_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h]))
-    for: 10m
+        namada_below_capacity_validators{chain_id="$$CHAIN_ID$$"}
+        - avg_over_time(namada_below_capacity_validators{chain_id="$$CHAIN_ID$$"}[7d])
+      ) > (2 * stddev_over_time(namada_below_capacity_validators{chain_id="$$CHAIN_ID$$"}[7d]))
     labels:
       severity: warning
     annotations:
       summary: "Abnormal increase in below-capacity validators"
       description: |
         The number of validators below capacity has increased abnormally.
-        Chain ID: namada.5f5de2dd1b88cba30586420
+        Block height: {{ with query "namada_block_height{chain_id=\"$$CHAIN_ID$$\"}" }}{{ printf "%d" (. | first | value) }}{{ end }}

--- a/composer/provisioning/prometheus/namada-alerts.yml
+++ b/composer/provisioning/prometheus/namada-alerts.yml
@@ -55,7 +55,6 @@ groups:
         Block height: {{ with query "namada_block_height{ chain_id=\"$$CHAIN_ID$$\" }" }}{{ printf "%.0f" (. | first | value)}}{{ end }}
         Chain id: {{ $labels.chain_id }}
 
-
   - alert: NamadaAbnormalUnbonding
     expr: rate(namada_unbonds_per_epoch{ chain_id="$$CHAIN_ID$$" }[10m]) > 1.5 * avg_over_time(namada_unbonds_per_epoch{ chain_id="$$CHAIN_ID$$" }[7d])
     labels:
@@ -92,8 +91,8 @@ groups:
       summary: "Anomalous Transaction Fees for Token {{ $labels.token }}"
       description: |
         Transaction fees per block for token {{ $labels.token }} have exceeded the expected range. 
-        Current: {{ $value }} NAM. 
-        Expected: < {{ with query "sum by (token) (avg_over_time(namada_fees{ chain_id=\"$$CHAIN_ID$$\" }[10m])) + 2 * sum by (token) (stddev_over_time(namada_fees{ chain_id=\"$$CHAIN_ID$$\" }[10m]))" }}{{ printf "%.2f" (. | first | value)}}{{ end }} NAM.
+        Current: {{ $value }}. 
+        Expected: < {{ with query "sum by (token) (avg_over_time(namada_fees{ chain_id=\"$$CHAIN_ID$$\" }[10m])) + 2 * sum by (token) (stddev_over_time(namada_fees{ chain_id=\"$$CHAIN_ID$$\" }[10m]))" }}{{ printf "%.2f" (. | first | value)}}{{ end }}.
         Chain id: {{ $labels.chain_id }}
 
   - alert: HighTransactionFeesAvg
@@ -129,7 +128,6 @@ groups:
         Block height: {{ with query "namada_block_height{chain_id=\"$$CHAIN_ID$$\"}" }}{{ printf "%.0f" (. | first | value) }}{{ end }}
         Chain id: {{ $labels.chain_id }}
 
-
   - alert: WhaleTransactionDetected
     expr: |
         transfer_amount{chain_id="$$CHAIN_ID$$"}
@@ -157,3 +155,78 @@ groups:
         Slashing detected.
         Block height: {{ with query "namada_block_height{chain_id=\"$$CHAIN_ID$$\"}" }}{{ printf "%.0f" (. | first | value) }}{{ end }}
         Chain id: {{ $labels.chain_id }}
+
+  - alert: AbnormalConsensusValidatorIncrease
+    expr: |
+      (
+        namada_consensus_validators{chain_id="namada.5f5de2dd1b88cba30586420"}
+        - avg_over_time(namada_consensus_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h])
+      ) > (2 * stddev_over_time(namada_consensus_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h]))
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Abnormal increase in consensus validators"
+      description: |
+        The number of validators in the consensus state has increased abnormally.
+        Chain ID: namada.5f5de2dd1b88cba30586420
+
+  - alert: AbnormalInactiveValidatorIncrease
+    expr: |
+      (
+        namada_inactive_validators{chain_id="namada.5f5de2dd1b88cba30586420"}
+        - avg_over_time(namada_inactive_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h])
+      ) > (2 * stddev_over_time(namada_inactive_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h]))
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Abnormal increase in inactive validators"
+      description: |
+        The number of inactive validators has increased abnormally.
+        Chain ID: namada.5f5de2dd1b88cba30586420
+
+  - alert: AbnormalJailedValidatorIncrease
+    expr: |
+      (
+        namada_jailed_validators{chain_id="namada.5f5de2dd1b88cba30586420"}
+        - avg_over_time(namada_jailed_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h])
+      ) > (2 * stddev_over_time(namada_jailed_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h]))
+    for: 10m
+    labels:
+      severity: critical
+    annotations:
+      summary: "Abnormal increase in jailed validators"
+      description: |
+        The number of jailed validators has increased abnormally.
+        Chain ID: namada.5f5de2dd1b88cba30586420
+
+  - alert: AbnormalBelowThresholdValidatorIncrease
+    expr: |
+      (
+        namada_below_threshold_validators{chain_id="namada.5f5de2dd1b88cba30586420"}
+        - avg_over_time(namada_below_threshold_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h])
+      ) > (2 * stddev_over_time(namada_below_threshold_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h]))
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Abnormal increase in below-threshold validators"
+      description: |
+        The number of validators below the threshold has increased abnormally.
+        Chain ID: namada.5f5de2dd1b88cba30586420
+
+  - alert: AbnormalBelowCapacityValidatorIncrease
+    expr: |
+      (
+        namada_below_capacity_validators{chain_id="namada.5f5de2dd1b88cba30586420"}
+        - avg_over_time(namada_below_capacity_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h])
+      ) > (2 * stddev_over_time(namada_below_capacity_validators{chain_id="namada.5f5de2dd1b88cba30586420"}[7d:1h]))
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Abnormal increase in below-capacity validators"
+      description: |
+        The number of validators below capacity has increased abnormally.
+        Chain ID: namada.5f5de2dd1b88cba30586420

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -9,6 +9,7 @@ mod total_supply_native_token;
 mod transactions;
 mod transfers;
 mod voting_power;
+mod validator;
 
 use std::{collections::HashMap, net::SocketAddr};
 
@@ -23,6 +24,7 @@ use total_supply_native_token::TotalSupplyNativeToken;
 use transactions::Transactions;
 use transfers::Transfers;
 use voting_power::VotingPower;
+use validator::ValidatorState;
 
 use crate::{config::AppConfig, state::State};
 use anyhow::{Context, Result};
@@ -78,6 +80,7 @@ impl MetricsExporter {
             Box::<Fees>::default() as Box<dyn MetricTrait>,
             Box::<Signatures>::default() as Box<dyn MetricTrait>,
             Box::<Slashes>::default() as Box<dyn MetricTrait>,
+            Box::<ValidatorState>::default() as Box<dyn MetricTrait>,
         ];
 
         Self::new(config, metrics)

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -8,8 +8,8 @@ pub mod slashes;
 mod total_supply_native_token;
 mod transactions;
 mod transfers;
-mod voting_power;
 mod validator;
+mod voting_power;
 
 use std::{collections::HashMap, net::SocketAddr};
 
@@ -23,8 +23,8 @@ use slashes::Slashes;
 use total_supply_native_token::TotalSupplyNativeToken;
 use transactions::Transactions;
 use transfers::Transfers;
-use voting_power::VotingPower;
 use validator::ValidatorState;
+use voting_power::VotingPower;
 
 use crate::{config::AppConfig, state::State};
 use anyhow::{Context, Result};

--- a/src/metrics/validator.rs
+++ b/src/metrics/validator.rs
@@ -1,0 +1,87 @@
+use super::MetricTrait;
+use crate::state::State;
+use anyhow::Result;
+use namada_sdk::proof_of_stake::types::ValidatorState as EnumValidatorState;
+use prometheus_exporter::prometheus::{
+    core::{AtomicU64, GenericCounter},
+    Registry,
+};
+
+pub struct ValidatorState {
+    pub consensus_validators: GenericCounter<AtomicU64>,
+    pub jailed_validators: GenericCounter<AtomicU64>,
+    pub inactive_validators: GenericCounter<AtomicU64>,
+    pub below_threshold_validators: GenericCounter<AtomicU64>,
+    pub below_capacity_validators: GenericCounter<AtomicU64>,
+}
+
+impl MetricTrait for ValidatorState {
+    fn register(&self, registry: &Registry) -> Result<()> {
+        registry.register(Box::new(self.consensus_validators.clone()))?;
+        registry.register(Box::new(self.jailed_validators.clone()))?;
+        registry.register(Box::new(self.inactive_validators.clone()))?;
+        registry.register(Box::new(self.below_threshold_validators.clone()))?;
+        registry.register(Box::new(self.below_capacity_validators.clone()))?;
+        Ok(())
+    }
+
+    fn reset(&self, state: &State) {
+        self.consensus_validators.reset();
+        self.jailed_validators.reset();
+        self.inactive_validators.reset();
+        self.below_threshold_validators.reset();
+        self.below_capacity_validators.reset();
+
+        for validator in state.get_validators() {
+            match validator.state {
+                EnumValidatorState::Consensus => self.consensus_validators.inc(),
+                EnumValidatorState::BelowCapacity => self.below_capacity_validators.inc(),
+                EnumValidatorState::BelowThreshold => self.below_threshold_validators.inc(),
+                EnumValidatorState::Inactive => self.inactive_validators.inc(),
+                EnumValidatorState::Jailed => self.jailed_validators.inc(),
+            }
+        }
+    }
+
+    fn update(&self, _pre_state: &State, post_state: &State) {
+        self.reset(post_state);
+    }
+}
+
+impl Default for ValidatorState {
+    fn default() -> Self {
+        let consensus_validators = GenericCounter::new(
+            "consensus_validators",
+            "Number of validators that are in consensus state",
+        )
+        .expect("unable to create consensus_validators");
+        let jailed_validators = GenericCounter::new(
+            "jailed_validators",
+            "Number of validators that are in jailed state",
+        )
+        .expect("unable to create jailed_validators");
+        let inactive_validators = GenericCounter::new(
+            "inactive_validators",
+            "Number of validators that are in inactive state",
+        )
+        .expect("unable to create inactive_validators");
+        let below_threshold_validators = GenericCounter::new(
+            "below_threshold_validators",
+            "Number of validators that are below the voting power threshold",
+        )
+        .expect("unable to create below_threshold_validators");
+        let below_capacity_validators = GenericCounter::new(
+            "below_capacity_validators",
+            "Number of validators that are below the capacity threshold",
+        )
+        .expect("unable to create below_capacity_validators");
+
+        Self {
+            consensus_validators,
+            jailed_validators,
+            inactive_validators,
+            below_threshold_validators,
+            below_capacity_validators,
+        }
+    }
+}

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -171,8 +171,12 @@ impl Rpc {
             None => Err(anyhow::anyhow!("Validator state not found")),
         }
     }
-    
-    pub async fn query_stake(&self, validator: &NamadaAddress, epoch: Epoch) -> anyhow::Result<u64> {
+
+    pub async fn query_stake(
+        &self,
+        validator: &NamadaAddress,
+        epoch: Epoch,
+    ) -> anyhow::Result<u64> {
         let futures = self
             .clients
             .iter()

--- a/src/shared/namada.rs
+++ b/src/shared/namada.rs
@@ -31,7 +31,7 @@ pub struct Validator {
     pub state: ValidatorState,
 }
 
-impl Validator{
+impl Validator {
     pub fn get_validator_state(&self) -> String {
         match self.state {
             ValidatorState::Consensus => "consensus".to_string(),

--- a/src/shared/namada.rs
+++ b/src/shared/namada.rs
@@ -2,6 +2,7 @@ use namada_sdk::borsh::BorshDeserialize;
 use namada_sdk::governance::{InitProposalData, VoteProposalData};
 use namada_sdk::ibc::{self, IbcMessage};
 use namada_sdk::key::common::PublicKey;
+use namada_sdk::proof_of_stake::types::ValidatorState;
 use namada_sdk::tendermint::block::Block as TendermintBlock;
 use namada_sdk::uint::Uint;
 use std::collections::BTreeMap;
@@ -27,6 +28,19 @@ pub type Address = String;
 pub struct Validator {
     pub address: String,
     pub voting_power: u64,
+    pub state: ValidatorState,
+}
+
+impl Validator{
+    pub fn get_validator_state(&self) -> String {
+        match self.state {
+            ValidatorState::Consensus => "consensus".to_string(),
+            ValidatorState::BelowCapacity => "below_capacity".to_string(),
+            ValidatorState::BelowThreshold => "below_threshold".to_string(),
+            ValidatorState::Inactive => "inactive".to_string(),
+            ValidatorState::Jailed => "jailed".to_string(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,7 +4,6 @@ use crate::shared::namada::{Address, Block, Height, Transfer, Validator};
 
 #[derive(Debug, Clone)]
 pub struct State {
-    //checksums: Checksums,
     block: Block,
     max_block_time_estimate: u64,
     total_supply_native: u64,
@@ -12,13 +11,11 @@ pub struct State {
     validators: Vec<Validator>,
     future_bonds: u64,
     future_unbonds: u64,
-    // peers: Vec<PeerInfo>,
 }
 
 impl State {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        //checksums: Checksums,
         block: Block,
         native_token: Address,
         max_block_time_estimate: u64,
@@ -26,10 +23,8 @@ impl State {
         validators: Vec<Validator>,
         future_bonds: u64,
         future_unbonds: u64,
-        // peers: Vec<PeerInfo>,
     ) -> Self {
         Self {
-            //checksums,
             block,
             native_token,
             max_block_time_estimate,
@@ -37,7 +32,6 @@ impl State {
             validators,
             future_bonds,
             future_unbonds,
-            // peers,
         }
     }
 
@@ -56,10 +50,6 @@ impl State {
     pub fn get_last_block(&self) -> &Block {
         &self.block
     }
-
-    // pub fn get_all_peers(&self) -> Vec<PeerInfo> {
-    //     self.peers.clone()
-    // }
 
     pub fn get_total_supply_for(&self, token: &Address) -> Option<u64> {
         if token == &self.native_token {
@@ -142,5 +132,8 @@ impl State {
 
     pub fn get_all_transfers(&self) -> Vec<Transfer> {
         self.block.get_all_transfers()
+    }
+    pub fn get_validators(&self) -> &Vec<Validator> {
+        &self.validators
     }
 }


### PR DESCRIPTION
Added metrics and rules to track validators states
fix https://github.com/heliaxdev/namada-monitoring/issues/43
```
# HELP namada_consensus_validators Number of validators that are in consensus state
# TYPE namada_consensus_validators counter
namada_consensus_validators{chain_id="namada.5f5de2dd1b88cba30586420"} 176

# HELP namada_inactive_validators Number of validators that are in inactive state
# TYPE namada_inactive_validators counter
namada_inactive_validators{chain_id="namada.5f5de2dd1b88cba30586420"} 9

# HELP namada_jailed_validators Number of validators that are in jailed state
# TYPE namada_jailed_validators counter
namada_jailed_validators{chain_id="namada.5f5de2dd1b88cba30586420"} 52

# HELP namada_below_capacity_validators Number of validators that are below the capacity threshold
# TYPE namada_below_capacity_validators counter
namada_below_capacity_validators{chain_id="namada.5f5de2dd1b88cba30586420"} 0

# HELP namada_below_threshold_validators Number of validators that are below the voting power threshold
# TYPE namada_below_threshold_validators counter
namada_below_threshold_validators{chain_id="namada.5f5de2dd1b88cba30586420"} 0
```