### PR TITLE
Remove the epoch from metric label

### DIFF
--- a/src/metrics/transactions.rs
+++ b/src/metrics/transactions.rs
@@ -80,10 +80,7 @@ impl MetricTrait for Transactions {
                 let inner_kind = inner.kind.to_string();
                 let failed = !inner.was_applied;
                 self.transaction_kind
-                    .with_label_values(&[
-                        &inner_kind,
-                        &failed.to_string(),
-                    ])
+                    .with_label_values(&[&inner_kind, &failed.to_string()])
                     .inc();
             }
         }
@@ -102,9 +99,8 @@ impl Default for Transactions {
 
         let transaction_kind_opts =
             Opts::new("transaction_kind", "Transaction kind count per epoch");
-        let transaction_kind =
-            IntCounterVec::new(transaction_kind_opts, &["kind", "failed"])
-                .expect("unable to create int counter for transaction kinds");
+        let transaction_kind = IntCounterVec::new(transaction_kind_opts, &["kind", "failed"])
+            .expect("unable to create int counter for transaction kinds");
 
         Self {
             transaction_batch_size,

--- a/src/metrics/transactions.rs
+++ b/src/metrics/transactions.rs
@@ -82,7 +82,6 @@ impl MetricTrait for Transactions {
                 self.transaction_kind
                     .with_label_values(&[
                         &inner_kind,
-                        &post_state.get_epoch().to_string(),
                         &failed.to_string(),
                     ])
                     .inc();
@@ -104,7 +103,7 @@ impl Default for Transactions {
         let transaction_kind_opts =
             Opts::new("transaction_kind", "Transaction kind count per epoch");
         let transaction_kind =
-            IntCounterVec::new(transaction_kind_opts, &["kind", "epoch", "failed"])
+            IntCounterVec::new(transaction_kind_opts, &["kind", "failed"])
                 .expect("unable to create int counter for transaction kinds");
 
         Self {


### PR DESCRIPTION
Epoch not used in alerts. Removed for now.